### PR TITLE
Pagination on Characters list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Features:
 - Dice roller with 3D css dice
 - Page to create a new character
 - Page to edit a character
+- Ability to delete a character
 - Page to view all characters in the database, sortable with some sort of summary of character info (not all info will be shown)
 - Page to see the details of a specific character (TBD to make this look like an actual character sheet)
 - Blog called "An Adventurer's Blog: A Day in the Life" which features blog posts from character adventures
@@ -17,8 +18,10 @@ I also may use https://www.dnd5eapi.co/ to query its apis to create something to
 
 ## Various TODOS
 - show logged in person's username in right corner of nav bar
-- pagination for the characters list and subsequent retrieval. offset-based?
-- fix issue on mobile where numeric fields that allow negatives can't have a negative entered because the mobile number pad doesn't have a "-" symbol (possibly fixed, tbd after deployment)
+- show character creator's username on character card, and have a filter for submitter
+- have a "my characters" and "all characters" tab
+- logger library that logs to somewhere other than console.log()?
+- various css fixes
 
 ## Technologies
 

--- a/codegen.json
+++ b/codegen.json
@@ -2,6 +2,10 @@
   "overwrite": true,
   "schema": "./src/app/api/graphql/typeDefs.ts",
   "documents": "./src/lib/graphql/queries.ts",
+  "config": {
+    "noSilentErrors": true,
+    "verbose": true
+  },
   "generates": {
     "src/generated/graphql/": {
       "preset": "client",

--- a/src/app/ApolloWrapper.tsx
+++ b/src/app/ApolloWrapper.tsx
@@ -16,8 +16,92 @@ function makeClient() {
   });
 
   return new ApolloClient({
-    cache: new InMemoryCache(),
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            characters: {
+              keyArgs: ['page'],
+              
+              // Custom merge function to handle merging different pages in cache
+              merge(existing, incoming, { args }) {
+                // If no args or no page, return incoming
+                if (!args) return incoming;
+
+                const { page = 1 } = args.input;
+                
+                // If no existing data, create a new object with empty characters array
+                const merged = existing ? { ...existing } : { 
+                  characters: [],
+                  totalCount: 0,
+                  totalPages: 0,
+                  pageSize: args.input.pageSize,
+                  hasNextPage: false,
+                  hasPreviousPage: false
+                };
+                
+                // Always take the latest metadata values
+                merged.totalCount = incoming.totalCount;
+                merged.totalPages = incoming.totalPages;
+                merged.pageSize = incoming.pageSize;
+                merged.hasNextPage = incoming.hasNextPage;
+                merged.hasPreviousPage = incoming.hasPreviousPage;
+                
+                // Store the characters for this specific page
+                // Note: We're creating a mutable copy of the characters array
+                const characters = merged.characters.slice(0);
+                
+                // Insert the incoming characters at the right position
+                const pageStartIndex = (page - 1) * incoming.pageSize;
+    
+                // Expand the array if needed to fit all characters
+                if (characters.length < pageStartIndex + incoming.characters.length) {
+                  characters.length = pageStartIndex + incoming.characters.length;
+                }
+                
+                // Insert the characters at the right position
+                for (let i = 0; i < incoming.characters.length; i++) {
+                  characters[pageStartIndex + i] = incoming.characters[i];
+                }
+                
+                // Update the merged object with the new characters array
+                merged.characters = characters;
+                merged.currentPage = page; // Store the current page
+
+                return merged;
+              },
+              
+              // Read function to extract just the current page data when requested
+              read(existing, { variables }) {
+                if (!existing || !variables) return existing;
+
+                const page = existing.currentPage;
+                const pageSize = existing.pageSize;
+                const pageStartIndex = (page - 1) * pageSize;
+                
+                // Create a copy with just the characters for the requested page
+                return {
+                  ...existing,
+                  currentPage: page,
+                  characters: existing.characters.slice(
+                    pageStartIndex, 
+                    pageStartIndex + pageSize
+                  ).filter(Boolean) // Filter out any null/undefined values
+                };
+              }
+            }
+          }
+        }
+      }
+    }),
     link: httpLink,
+    defaultOptions: {
+      watchQuery: {
+        // This controls whether to fetch from network, cache, or both
+        fetchPolicy: 'cache-first', // Get quick response from cache, but also update from network
+        nextFetchPolicy: 'cache-and-network',
+      },
+    },
   });
 }
 

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -7,9 +7,10 @@ import { authOptions } from '@/lib/auth';
 
 const resolvers: Resolvers = {
   Query: {
-    characters: async () => {
+    characters: async (_root, { input }) => {
       try {
-        return await getAllCharacters();
+        const sanitized = sanitizeVariables(input);
+        return await getAllCharacters(sanitized);
       } catch (error) {
         console.log(error);
         throw new Error("Failed to fetch characters");

--- a/src/app/api/graphql/typeDefs.ts
+++ b/src/app/api/graphql/typeDefs.ts
@@ -16,29 +16,29 @@ const typeDefs = `#graphql
   }
 
   type Skill {
-    id: Int
-    skill: String
+    id: Int!
+    skill: String!
   }
 
   type Race {
-    id: Int
-    raceName: String
-    raceType: String
+    id: Int!
+    raceName: String!
+    raceType: String!
   }
 
   type Class {
-    id: Int
-    className: String
+    id: Int!
+    className: String!
   }
 
   type Alignment {
-    id: Int
-    alignment: String
+    id: Int!
+    alignment: String!
   }
 
   type Ability {
-    id: Int
-    ability: String
+    id: Int!
+    ability: String!
   }
 
   type CharacterAbility {
@@ -76,22 +76,22 @@ const typeDefs = `#graphql
   }
 
   input NewCharacterInput {
-    name: String!,
-    level: Int!,
-    raceId: Int!,
-    classId: Int!,
-    armorClass: Int!,
-    speed: Int!,
-    hp: Int!,
-    initiative: Int!,
-    proficiencyBonus: Int!,
-    alignmentId: Int!,
+    name: String!
+    level: Int!
+    raceId: Int!
+    classId: Int!
+    armorClass: Int!
+    speed: Int!
+    hp: Int!
+    initiative: Int!
+    proficiencyBonus: Int!
+    alignmentId: Int!
   }
 
   input CreateCharacterInput {
-    character: NewCharacterInput!,
-    skills: [NewCharacterSkillInput]!,
-    abilities: [NewCharacterAbilityInput]!,
+    character: NewCharacterInput!
+    skills: [NewCharacterSkillInput]!
+    abilities: [NewCharacterAbilityInput]!
   }
 
   input UpdateCharacterSkillInput {
@@ -106,23 +106,42 @@ const typeDefs = `#graphql
   }
 
   input UpdateCharacterInput {
-    id: Int!,
-    name: String,
-    level: Int,
-    raceId: Int,
-    classId: Int,
-    armorClass: Int,
-    speed: Int,
-    hp: Int,
-    initiative: Int,
-    proficiencyBonus: Int,
-    alignmentId: Int,
-    skills: [UpdateCharacterSkillInput],
-    abilities: [UpdateCharacterAbilityInput],
+    id: Int!
+    name: String
+    level: Int
+    raceId: Int
+    classId: Int
+    armorClass: Int
+    speed: Int
+    hp: Int
+    initiative: Int
+    proficiencyBonus: Int
+    alignmentId: Int
+    skills: [UpdateCharacterSkillInput]
+    abilities: [UpdateCharacterAbilityInput]
+  }
+
+  type CharactersPage {
+    characters: [Character!]!
+    totalCount: Int!
+    totalPages: Int!
+    currentPage: Int!
+    pageSize: Int!
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+  }
+
+  input QueryCharactersInput {
+    page: Int!
+    pageSize: Int!
+    race: Int
+    class: Int
+    alignment: Int
+    name: String
   }
 
   type Query {
-    characters: [Character!]!
+    characters(input: QueryCharactersInput!): CharactersPage!
     character(id: Int!): Character
 
     skills: [Skill!]!

--- a/src/components/characters/CharacterFilters.tsx
+++ b/src/components/characters/CharacterFilters.tsx
@@ -1,49 +1,31 @@
 'use client'
 
-import { Character } from '@/generated/graphql/graphql';
 import { useState, useMemo, useEffect } from 'react';
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
+import { useCharacterFiltersReferenceValues } from '@/lib/graphql/hooks';
 import Button from '@/components/shared/Button';
 
 interface Props {
-  characters: Character[],
-  onFilterChange: (filteredCharacters: Character[]) => void,
+  onFilterChange: (classType: number, race: number, alignment: number, searchTerm: string) => void,
 }
 
-const CharacterFilters: React.FC<Props> = ({ characters, onFilterChange }) => {
+const SkeletonComponent = () => (
+  <SkeletonTheme baseColor="#211b4b" highlightColor="#310e5a">
+    <section>
+      <Skeleton count={1} className='h-28 ring-1 ring-blue-700/50' />
+    </section>
+  </SkeletonTheme>
+);
+
+const CharacterFilters: React.FC<Props> = ({ onFilterChange }) => {
+  const { races, classes, alignments, error, refetch, loading } = useCharacterFiltersReferenceValues();
+
   const [searchTerm, setSearchTerm] = useState('')
   const [filters, setFilters] = useState({
     class: '',
     race: '',
     alignment: '',
   });
-
-  /**
-   * uniqueValues
-   * An object of class, alignment, and race keys with unique values from all characters for each key
-   */
-  const uniqueValues = useMemo(() => ({
-    race: [...new Set(characters.map(char => char.race?.raceType).sort())],
-    alignment: [...new Set(characters.map(char => char.alignment?.alignment).sort())],
-    class: [...new Set(characters.map(char => char.class?.className).sort())]
-  }), [characters]);
-
-  /**
-   * useEffect
-   * On search term or filter change, filter characters and call params function
-   */
-  useEffect(() => {
-    const filtered = characters.filter(character => {
-      const name = character.name ?? '';
-      const matchesSearch = name.toLowerCase().includes(searchTerm.toLowerCase())
-      const matchesRace = !filters.race || character.race?.raceType === filters.race
-      const matchesAlignment = !filters.alignment || character.alignment?.alignment === filters.alignment
-      const matchesClass = !filters.class || character.class?.className === filters.class
-
-      return matchesSearch && matchesRace && matchesClass && matchesAlignment;
-    });
-
-    onFilterChange(filtered);
-  }, [searchTerm, filters])
 
    /**
     * handleFilterChange
@@ -71,9 +53,80 @@ const CharacterFilters: React.FC<Props> = ({ characters, onFilterChange }) => {
       alignment: '',
     });
     setSearchTerm('');
+    onFilterChange(0, 0, 0, '');
   };
 
+  /**
+   * onFilter
+   * TBD
+   */
+  const onFilter = () => {
+    onFilterChange(+filters.class, +filters.race, +filters.alignment, searchTerm);
+  }
+
   const commonClasses = 'bg-purple-950/60 border border-blue-800 rounded-lg text-white px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-700 focus:border-purple-700';
+
+  const createFilter = (type: 'class' | 'race' | 'alignment') => {
+    let text: string = '';
+    let filterValues: { key: string, value: string }[] = [];
+
+    if (type === 'race') {
+      text = 'Races';
+      filterValues = races ? races.map((race) => ({ key: race.id.toString(), value: race.raceName })) : [];
+    } else if (type === 'alignment') {
+      text = 'Alignments';
+      filterValues = alignments ? alignments.map((alignment) => ({ key: alignment.id.toString(), value: alignment.alignment })) : [];
+    } else if (type === 'class') {
+      text = 'Classes';
+      filterValues = classes ? classes.map((classType) => ({ key: classType.id.toString(), value: classType.className })) : [];
+    }
+
+    return (
+      <div>
+        <div className='pb-2'>
+          <label
+              htmlFor={`${type}-filter`}
+              id={`${type}-filter`}
+              aria-label={`Filter by ${text}`}
+              className="pr-4"
+            >
+              Filter by {text}
+            </label>
+        </div>
+        <select
+          id={`${type}-filter`}
+          value={filters[type]}
+          onChange={(e) => {
+            handleFilterChange(type, e.target.value);
+          }}
+          className={commonClasses}
+        >
+          <option value="">All {text}</option>
+          {filterValues.map((value) => (
+            <option key={value.key} value={value.key}>{value.value}</option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+
+  if (loading) return <SkeletonComponent />
+
+  if (error) {
+    return (
+      <>
+        <div className="space-y-4 bg-indigo-950 ring-2 ring-blue-700/50 p-4 rounded-lg">
+          <p>Error! Filters failed to load.</p>
+          <Button
+            text="Try Again"
+            onClick={() =>  {
+              refetch()
+            }}
+          />
+        </div>
+      </>
+    )
+  }
 
   return (
     <>
@@ -95,65 +148,32 @@ const CharacterFilters: React.FC<Props> = ({ characters, onFilterChange }) => {
             id="name-search"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className={`w-full placeholder-gray-400 ${commonClasses}`}
+            className={`w-full ${commonClasses}`}
           />
         </div>
 
         {/* Filter Dropdowns */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {Object.entries(filters).map(([key]) => {
-            const typedKey = key as keyof typeof uniqueValues | keyof typeof filters;
-            const filterValues = uniqueValues[typedKey]
-                                  .filter((value) => value !== undefined && value !== null)
-                                  .map((value: string) => value);
-            let text: string = '';
+          {createFilter('class')}
+          {createFilter('race')}
+          {createFilter('alignment')}
+        </div>
 
-            if (key === 'race') {
-              text = 'Races';
-            } else if (key === 'alignment') {
-              text = 'Alignments';
-            } else if (key === 'class') {
-              text = 'Classes';
-            }
-
-            return (
-              <div key={key}>
-                <div className='pb-2'>
-                  <label
-                      htmlFor={`${key}-filter`}
-                      id={`${key}-filter`}
-                      aria-label={`Filter by ${key}`}
-                      className="pr-4"
-                    >
-                      Filter by {key.charAt(0).toUpperCase() + key.slice(1)}
-                    </label>
-                </div>
-                <select
-                  id={`${key}-filter`}
-                  value={filters[typedKey]}
-                  onChange={(e) => {
-                    handleFilterChange(key, e.target.value);
-                  }}
-                  className={`${commonClasses}`}
-                >
-                  <option value="">All {text}</option>
-                  {filterValues.map((value: string) => (
-                    <option key={value} value={value}>{value}</option>
-                  ))}
-                </select>
-              </div>
-            )
-          })}
+        <div className='mt-10'>
+          <Button
+            text="Filter"
+            type="button"
+            onClick={onFilter}
+            cssMargin='mr-3'
+          />
+          <Button
+            text="Clear Filters"
+            type="button"
+            disabled={filters.race === '' && filters.alignment === '' && filters.class === '' && searchTerm === '' }
+            onClick={clearFilters}
+          />
         </div>
       </div>
-      <div className='mt-5'>
-        <Button
-          text="Clear Filters"
-          type="button"
-          onClick={clearFilters}
-        />
-      </div>
-      
     </>
   )
 }

--- a/src/components/characters/CharacterList.tsx
+++ b/src/components/characters/CharacterList.tsx
@@ -1,42 +1,123 @@
 'use client'
 
-import { useEffect, useState } from 'react';
-import { Character } from '@/generated/graphql/graphql';
+import { useCallback, useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { Character, QueryCharactersInput } from '@/generated/graphql/graphql';
 import CharacterCard from './CharacterCard';
 import CharacterFilters from './CharacterFilters';
 import { useCharacters } from '@/lib/graphql/hooks';
 import ErrorLoading from '../shared/ErrorLoading';
+import Paginator from '../shared/Paginator';
+import { PAGE_SIZE } from '@/constants';
+import ResultsPerPage from '../shared/ResultsPerPage';
 
 const CharacterList = () => {
-  const { characters, error, refetch } = useCharacters();
+  const pathname = usePathname()
+
+  const { data, error, refetch, fetchMore } = useCharacters();
 
   const [sortedCharacters, setSortedCharacters] = useState<Character[]>([]);
-  const [filteredResults, setFilteredResults] = useState<Character[]>([]);
+  const [resultsPerPage, setResultsPerPage] = useState(PAGE_SIZE);
+  const [filters, setFilters] = useState({
+    class: 0,
+    race: 0,
+    alignment: 0,
+    searchTerm: '',
+  });
+
+  useEffect(() => {
+    // This runs whenever the pathname changes
+    if (pathname === '/characters') {
+      const input: QueryCharactersInput = {
+        page: 1,
+        pageSize: PAGE_SIZE
+      };
+      refetch({ input });
+    }
+  }, [pathname])
+
+  const characters = data?.characters.characters;
+
   /**
    * useEffect
    * sorts characters by name A-Z when characters array changes
    */
   useEffect(() => {
-    if (characters) {
+    if (characters && characters.length > 1) {
       const sorted = [...characters].sort((a, b) => {
         if (a.name!.toLowerCase() < b.name!.toLowerCase()) return -1;
         if (a.name!.toLowerCase() > b.name!.toLowerCase()) return 1;
         return 0;
       });
 
-    setSortedCharacters(sorted);
-    setFilteredResults(sorted);
+      setSortedCharacters(sorted);
     }
   }, [characters]);
 
   /**
-   * handleFilterChange
-   * sets state for filtered characters
-   * @param filteredCharacters array of characters
+   * handlePageChange
+   * Builds the input object and uses fetchMore to fetch more results on page change
+   * @param pageNumber number
    */
-  const handleFilterChange = (filteredCharacters: Character[]) => {
-    setFilteredResults(filteredCharacters);
+  const handlePageChange = useCallback((pageNumber: number) => {
+    const input: QueryCharactersInput = {
+      page: pageNumber,
+      pageSize: resultsPerPage,
+    }
+
+    if (filters.class !== 0) input.class = filters.class;
+    if (filters.race !== 0) input.race = filters.race;
+    if (filters.alignment !== 0) input.alignment = filters.alignment;
+    if (filters.searchTerm.trim() !== '') input.name = filters.searchTerm;
+
+    fetchMore({ variables: { input } })
+  }, [resultsPerPage, filters])
+
+  /**
+   * useEffect
+   * Calls the function to change page to 1 on results per page change
+   */
+  useEffect(() => {
+    handlePageChange(1);
+  }, [resultsPerPage, handlePageChange])
+
+  /**
+   * handleFilterChange
+   * Builds the input object, sets state for filters, and uses refetch to refetch the data on filter change
+   * @param classType number
+   * @param race number
+   * @param alignment number
+   * @param searchTerm string
+   */
+  const handleFilterChange = (classType: number, race: number, alignment: number, searchTerm: string) => {
+    const input: QueryCharactersInput = {
+      page: 1,
+      pageSize: resultsPerPage
+    }
+
+    if (classType !== 0) input.class = classType;
+    if (race !== 0) input.race = race;
+    if (alignment !== 0) input.alignment = alignment;
+    if (searchTerm.trim() !== '') input.name = searchTerm;
+
+    setFilters({
+      class: classType,
+      race: race,
+      alignment: alignment,
+      searchTerm: searchTerm,
+    })
+
+    refetch({ input })
   }
+
+  /**
+   * handleResultsPerPageChange
+   * Sets state for results per page
+   * @param count number
+   */
+  const handleResultsPerPageChange = (count: number) => {
+    setResultsPerPage(count);
+  };
 
   if (error) {
     return <ErrorLoading refetch={refetch} />
@@ -45,13 +126,15 @@ const CharacterList = () => {
   return (
     <>
       <div>
-        <CharacterFilters 
-          characters={sortedCharacters}
+        <CharacterFilters
           onFilterChange={handleFilterChange}
         />
       </div>
+      <div className='mt-6 flex justify-end'>
+        <ResultsPerPage onNumberChange={handleResultsPerPageChange} />
+      </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 pt-7">
-        {filteredResults.map((character, index) => (
+        {sortedCharacters.map((character, index) => (
           <CharacterCard
             key={character.id}
             character={character}
@@ -59,6 +142,20 @@ const CharacterList = () => {
           />
         ))}
       </div>
+      {data && (
+        <div className='mt-10'>
+          <Paginator
+            totalPages={data.characters.totalPages}
+            totalResults={data.characters.totalCount}
+            currentPage={data.characters.currentPage}
+            pageSize={data.characters.pageSize}
+            onPageChange={handlePageChange}
+            hasNextPage={data.characters.hasNextPage}
+            hasPreviousPage={data.characters.hasPreviousPage}
+          />
+        </div>
+      )}
+      
     </>
   );
 }

--- a/src/components/diceroller/DiceNumberInput.tsx
+++ b/src/components/diceroller/DiceNumberInput.tsx
@@ -26,6 +26,7 @@ const DiceNumberInput: React.FC<Props> = ({ onNumberSelect, diceType, register }
         type="number"
         id={`${diceType}Input`}
         min={0}
+        max={30}
         {...register(`${diceType}Input`, { valueAsNumber: true })}
         onChange={(e) => onNumberSelect(e, diceType)}
         className="w-14 px-2 py-1 bg-purple-950/60 border border-violet-800 rounded-md shadow-sm text-indigo-50 focus:outline-none focus:ring-2 focus:ring-purple-700 focus:border-purple-700"

--- a/src/components/diceroller/DiceRoller.tsx
+++ b/src/components/diceroller/DiceRoller.tsx
@@ -229,7 +229,7 @@ const DiceRoller: React.FC = () => {
             cssMargin='mb-5 sm:mb-0 sm:mr-5'
           />
           <Button
-            text="Reset Totals"
+            text="Reset Rolls"
             type="button"
             onClick={resetTotals}
             cssMargin='mb-5 sm:mb-0 sm:mr-5'

--- a/src/components/shared/Paginator.tsx
+++ b/src/components/shared/Paginator.tsx
@@ -1,0 +1,237 @@
+/**
+ * Button
+ * Reusable component for page number buttons on non-mobile view
+ */
+
+interface ButtonProps {
+  pageNumber: number;
+  currentPage: number;
+  onPageChange: (pageNumber: number) => void;
+  totalPages: number;
+}
+
+const Button: React.FC<ButtonProps> = ({
+    pageNumber,
+    currentPage,
+    onPageChange,
+    totalPages,
+  }) => {
+  const css = currentPage === pageNumber ? 'z-10 bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-inset focus:border-purple-700' : 'ring-1 ring-inset focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-inset focus:border-purple-700';
+  let roundedCss = '';
+  if (currentPage === totalPages && pageNumber === totalPages) {
+    roundedCss = 'rounded-r-md';
+  } else if (currentPage === 1 && pageNumber === 1) {
+    roundedCss = 'rounded-l-md';
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onPageChange(pageNumber)}
+      className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold focus:z-20 hover:bg-indigo-900 ${css} ${roundedCss}`}
+    >
+      {pageNumber}
+    </button>
+  )
+};
+
+/**
+ * EdgeButtons
+ * Component for the first/last buttons on non-mobile view
+ */
+
+interface EdgeButtonsProps {
+  type: 'prev' | 'next';
+  onPageChange: (pageNumber: number) => void;
+  totalPages: number;
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+}
+
+const EdgeButtons: React.FC<EdgeButtonsProps> = ({
+    type,
+    onPageChange,
+    totalPages,
+    hasPreviousPage,
+    hasNextPage
+  }) => {
+  if (type === 'prev' && hasPreviousPage) {
+    return (
+      <button
+        type="button"
+        onClick={() => onPageChange(1)}
+        disabled={!hasPreviousPage}
+        className="relative inline-flex items-center px-2 py-2 ring-1 rounded-l-md ring-inset focus:z-20 hover:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-inset focus:border-purple-700"
+      >
+        First
+      </button>
+    )
+  } else if (type === 'next' && hasNextPage) {
+    return (
+      <button
+        type="button"
+        onClick={() => onPageChange(totalPages)}
+        disabled={!hasNextPage}
+        className="relative inline-flex items-center px-2 py-2 ring-1 rounded-r-md ring-inset focus:z-20 hover:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-inset focus:border-purple-700"
+      >
+        Last
+      </button>
+    )
+  }
+};
+
+/**
+ * MobileEdgeButtons
+ * Component for the previous/next buttons on mobile view
+ */
+
+interface MobileEdgeButtonsProps {
+  onPageChange: (pageNumber: number) => void;
+  currentPage: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+const MobileEdgeButtons: React.FC<MobileEdgeButtonsProps> = ({
+  onPageChange,
+  currentPage,
+  hasNextPage,
+  hasPreviousPage
+}) => {
+  return (
+    <div className="flex flex-1 justify-between sm:hidden">
+      <button
+        type="button"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={!hasPreviousPage}
+        className="relative inline-flex items-center px-2 py-2 ring-1 rounded-md ring-inset focus:z-20 hover:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-inset focus:border-purple-700"
+      >
+        Previous
+      </button>
+      <button
+        type="button"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={!hasNextPage}
+        className="relative inline-flex items-center px-2 py-2 ring-1 rounded-md ring-inset focus:z-20 hover:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-inset focus:border-purple-700"
+      >
+        Next
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Paginator
+ * pagination component
+ */
+
+interface Props {
+  totalResults: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (pageNumber: number) => void;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+const Paginator: React.FC<Props> = ({
+  totalResults,
+  totalPages,
+  currentPage,
+  pageSize,
+  onPageChange,
+  hasNextPage,
+  hasPreviousPage
+}) => {
+  const startResultNumber = ((pageSize * (currentPage - 1)) + 1) || 1;
+  const endResultNumber = hasNextPage ? (startResultNumber + (pageSize - 1)) : totalResults;
+
+  /**
+   * createPageButtons
+   * Creates the inner page buttons
+   * @returns array of jsx items
+   */
+  const createPageButtons = () => {
+    // if total number of pages is <= 4, show all buttons
+    if (totalPages <= 4) {
+      return [...new Array(totalPages)].map((_val, index) => (
+        <Button
+          pageNumber={index + 1}
+          currentPage={currentPage}
+          key={index + 1}
+          onPageChange={onPageChange}
+          totalPages={totalPages}
+        />
+      ))
+    }
+
+    // else, show specific pages. if not pages 1 to 2, or last-1 to last, then show prev current next)
+    return [...new Array(totalPages)].map((_val, index) => {
+      const page = index + 1;
+      if (
+        (currentPage === 1 && (page - currentPage < 2))
+        || (currentPage === page)
+        || (currentPage - page === 1 || page - currentPage === 1)
+      ) {
+        return (
+          <Button
+            pageNumber={page}
+            currentPage={currentPage}
+            key={page}
+            onPageChange={onPageChange}
+            totalPages={totalPages}
+          />
+        )
+      } else if (
+        (currentPage < page && page - currentPage < 3)
+        || (currentPage > page && currentPage - page < 3)
+      ) {
+        return <span key={page} className="relative inline-flex items-center px-4 py-2 text-sm font-semibol ring-1 ring-inset focus:outline-none">...</span>;
+      }
+      else {
+        return null;
+      }
+      
+    }).filter((item) => item !== null);
+  }
+
+  return (
+    <div className="flex items-center justify-between ring-1 ring-blue-700/50 bg-indigo-950 px-4 py-3 sm:px-6">
+      <MobileEdgeButtons
+        currentPage={currentPage}
+        onPageChange={onPageChange}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+      />
+      <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm">
+            Showing {startResultNumber} to {endResultNumber} of {totalResults} results
+          </p>
+        </div>
+        <div>
+          <nav className="isolate inline-flex -space-x-px rounded-md" aria-label="Pagination">
+            <EdgeButtons
+              type='prev'
+              onPageChange={onPageChange}
+              totalPages={totalPages}
+              hasNextPage={hasNextPage}
+              hasPreviousPage={hasPreviousPage}
+            />
+            {createPageButtons()}
+            <EdgeButtons
+              type='next'
+              onPageChange={onPageChange}
+              totalPages={totalPages}
+              hasNextPage={hasNextPage}
+              hasPreviousPage={hasPreviousPage}
+            />
+          </nav>
+        </div>
+      </div>
+    </div>
+  )
+};
+
+export default Paginator;

--- a/src/components/shared/ResultsPerPage.tsx
+++ b/src/components/shared/ResultsPerPage.tsx
@@ -1,0 +1,37 @@
+import { PAGE_SIZE } from '@/constants';
+
+const ResultsPerPage: React.FC<{ onNumberChange: (number: number) => void }> = ({ onNumberChange }) => {
+
+  const handleNumberChange = (value: string) => {
+    onNumberChange(+value);
+  }
+
+  return (
+    <div>
+      <div className='pb-2 inline-block'>
+        <label
+            htmlFor="results-per-page-filter-input"
+            id="results-per-page-filter"
+            aria-label="Results Per Page"
+            className="pr-4"
+          >
+            Results Per Page
+          </label>
+      </div>
+      <select
+        id="results-per-page-filter-input"
+        defaultValue={PAGE_SIZE.toString()}
+        onChange={(e) => {
+          handleNumberChange(e.target.value);
+        }}
+        className="bg-purple-950/60 border border-blue-800 rounded-lg text-white px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-700 focus:border-purple-700"
+      >
+          <option key={PAGE_SIZE.toString()} value={PAGE_SIZE.toString()}>{PAGE_SIZE}</option>
+          <option key="36" value="36">36</option>
+          <option key="60" value="60">60</option>
+      </select>
+    </div>
+  )
+};
+
+export default ResultsPerPage;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 12;

--- a/src/generated/graphql/gql.ts
+++ b/src/generated/graphql/gql.ts
@@ -15,7 +15,7 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  */
 type Documents = {
     "\n  fragment CharacterDetail on Character {\n    id\n    name\n    level\n    hp\n    alignment {\n      id\n      alignment\n    }\n    race {\n      id\n      raceName\n      raceType\n    }\n    class {\n      id\n      className\n    }\n  }\n": typeof types.CharacterDetailFragmentDoc,
-    "\n  query GetCharacters {\n    characters {\n      ...CharacterDetail\n    }\n  }\n": typeof types.GetCharactersDocument,
+    "\n  query GetCharacters($input: QueryCharactersInput!) {\n    characters(input: $input) {\n      characters {\n        ...CharacterDetail\n      }\n      totalCount\n      totalPages\n      currentPage\n      pageSize\n      hasNextPage\n      hasPreviousPage\n    }\n  }\n": typeof types.GetCharactersDocument,
     "\n  query GetSingleCharacter($id: Int!) {\n    character(id: $id) {\n      ...CharacterDetail\n      initiative\n      proficiencyBonus\n      speed\n      skills {\n        skill {\n          id\n          skill\n        }\n        id\n        skillProficiency\n      }\n      abilities {\n        id\n        abilityScore\n        proficiencyBonus\n        ability {\n          id\n          ability\n        }\n      }\n    }\n  }\n": typeof types.GetSingleCharacterDocument,
     "\n  query getPartialCharacterById($id: Int!) {\n    character(id: $id) {\n      ...CharacterDetail\n    }\n  }\n": typeof types.GetPartialCharacterByIdDocument,
     "\n  query GetRaces {\n    races {\n      id\n      raceName\n      raceType\n    }\n  }\n": typeof types.GetRacesDocument,
@@ -24,10 +24,11 @@ type Documents = {
     "\n  query GetSkills {\n    skills {\n      id\n      skill\n    }\n  }\n": typeof types.GetSkillsDocument,
     "\n  query GetAbilities {\n    abilities {\n      id\n      ability\n    }\n  }\n": typeof types.GetAbilitiesDocument,
     "\n  query GetreferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      abilities {\n        id\n        ability\n      }\n      skills {\n        id\n        skill\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n": typeof types.GetreferenceValuesDocument,
+    "\n  query GetCharacterFiltersReferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n": typeof types.GetCharacterFiltersReferenceValuesDocument,
 };
 const documents: Documents = {
     "\n  fragment CharacterDetail on Character {\n    id\n    name\n    level\n    hp\n    alignment {\n      id\n      alignment\n    }\n    race {\n      id\n      raceName\n      raceType\n    }\n    class {\n      id\n      className\n    }\n  }\n": types.CharacterDetailFragmentDoc,
-    "\n  query GetCharacters {\n    characters {\n      ...CharacterDetail\n    }\n  }\n": types.GetCharactersDocument,
+    "\n  query GetCharacters($input: QueryCharactersInput!) {\n    characters(input: $input) {\n      characters {\n        ...CharacterDetail\n      }\n      totalCount\n      totalPages\n      currentPage\n      pageSize\n      hasNextPage\n      hasPreviousPage\n    }\n  }\n": types.GetCharactersDocument,
     "\n  query GetSingleCharacter($id: Int!) {\n    character(id: $id) {\n      ...CharacterDetail\n      initiative\n      proficiencyBonus\n      speed\n      skills {\n        skill {\n          id\n          skill\n        }\n        id\n        skillProficiency\n      }\n      abilities {\n        id\n        abilityScore\n        proficiencyBonus\n        ability {\n          id\n          ability\n        }\n      }\n    }\n  }\n": types.GetSingleCharacterDocument,
     "\n  query getPartialCharacterById($id: Int!) {\n    character(id: $id) {\n      ...CharacterDetail\n    }\n  }\n": types.GetPartialCharacterByIdDocument,
     "\n  query GetRaces {\n    races {\n      id\n      raceName\n      raceType\n    }\n  }\n": types.GetRacesDocument,
@@ -36,6 +37,7 @@ const documents: Documents = {
     "\n  query GetSkills {\n    skills {\n      id\n      skill\n    }\n  }\n": types.GetSkillsDocument,
     "\n  query GetAbilities {\n    abilities {\n      id\n      ability\n    }\n  }\n": types.GetAbilitiesDocument,
     "\n  query GetreferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      abilities {\n        id\n        ability\n      }\n      skills {\n        id\n        skill\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n": types.GetreferenceValuesDocument,
+    "\n  query GetCharacterFiltersReferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n": types.GetCharacterFiltersReferenceValuesDocument,
 };
 
 /**
@@ -59,7 +61,7 @@ export function graphql(source: "\n  fragment CharacterDetail on Character {\n  
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query GetCharacters {\n    characters {\n      ...CharacterDetail\n    }\n  }\n"): (typeof documents)["\n  query GetCharacters {\n    characters {\n      ...CharacterDetail\n    }\n  }\n"];
+export function graphql(source: "\n  query GetCharacters($input: QueryCharactersInput!) {\n    characters(input: $input) {\n      characters {\n        ...CharacterDetail\n      }\n      totalCount\n      totalPages\n      currentPage\n      pageSize\n      hasNextPage\n      hasPreviousPage\n    }\n  }\n"): (typeof documents)["\n  query GetCharacters($input: QueryCharactersInput!) {\n    characters(input: $input) {\n      characters {\n        ...CharacterDetail\n      }\n      totalCount\n      totalPages\n      currentPage\n      pageSize\n      hasNextPage\n      hasPreviousPage\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -92,6 +94,10 @@ export function graphql(source: "\n  query GetAbilities {\n    abilities {\n    
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  query GetreferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      abilities {\n        id\n        ability\n      }\n      skills {\n        id\n        skill\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n"): (typeof documents)["\n  query GetreferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      abilities {\n        id\n        ability\n      }\n      skills {\n        id\n        skill\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query GetCharacterFiltersReferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n"): (typeof documents)["\n  query GetCharacterFiltersReferenceValues {\n    referenceValues {\n      races {\n        id\n        raceName\n        raceType\n      }\n      classes {\n        id\n        className\n      }\n      alignments {\n        id\n        alignment\n      }\n    }\n  }\n"];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/src/generated/graphql/graphql.ts
+++ b/src/generated/graphql/graphql.ts
@@ -20,14 +20,14 @@ export type Scalars = {
 
 export type Ability = {
   __typename?: 'Ability';
-  ability?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
+  ability: Scalars['String']['output'];
+  id: Scalars['Int']['output'];
 };
 
 export type Alignment = {
   __typename?: 'Alignment';
-  alignment?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
+  alignment: Scalars['String']['output'];
+  id: Scalars['Int']['output'];
 };
 
 export type Character = {
@@ -64,10 +64,21 @@ export type CharacterSkill = {
   skillProficiency?: Maybe<Scalars['Int']['output']>;
 };
 
+export type CharactersPage = {
+  __typename?: 'CharactersPage';
+  characters: Array<Character>;
+  currentPage: Scalars['Int']['output'];
+  hasNextPage: Scalars['Boolean']['output'];
+  hasPreviousPage: Scalars['Boolean']['output'];
+  pageSize: Scalars['Int']['output'];
+  totalCount: Scalars['Int']['output'];
+  totalPages: Scalars['Int']['output'];
+};
+
 export type Class = {
   __typename?: 'Class';
-  className?: Maybe<Scalars['String']['output']>;
-  id?: Maybe<Scalars['Int']['output']>;
+  className: Scalars['String']['output'];
+  id: Scalars['Int']['output'];
 };
 
 export type CreateCharacterInput = {
@@ -129,7 +140,7 @@ export type Query = {
   alignment?: Maybe<Alignment>;
   alignments: Array<Alignment>;
   character?: Maybe<Character>;
-  characters: Array<Character>;
+  characters: CharactersPage;
   class?: Maybe<Class>;
   classes: Array<Class>;
   race?: Maybe<Race>;
@@ -155,6 +166,11 @@ export type QueryCharacterArgs = {
 };
 
 
+export type QueryCharactersArgs = {
+  input: QueryCharactersInput;
+};
+
+
 export type QueryClassArgs = {
   id: Scalars['Int']['input'];
 };
@@ -169,17 +185,26 @@ export type QuerySkillArgs = {
   id: Scalars['Int']['input'];
 };
 
+export type QueryCharactersInput = {
+  alignment?: InputMaybe<Scalars['Int']['input']>;
+  class?: InputMaybe<Scalars['Int']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  page: Scalars['Int']['input'];
+  pageSize: Scalars['Int']['input'];
+  race?: InputMaybe<Scalars['Int']['input']>;
+};
+
 export type Race = {
   __typename?: 'Race';
-  id?: Maybe<Scalars['Int']['output']>;
-  raceName?: Maybe<Scalars['String']['output']>;
-  raceType?: Maybe<Scalars['String']['output']>;
+  id: Scalars['Int']['output'];
+  raceName: Scalars['String']['output'];
+  raceType: Scalars['String']['output'];
 };
 
 export type Skill = {
   __typename?: 'Skill';
-  id?: Maybe<Scalars['Int']['output']>;
-  skill?: Maybe<Scalars['String']['output']>;
+  id: Scalars['Int']['output'];
+  skill: Scalars['String']['output'];
 };
 
 export type UpdateCharacterAbilityInput = {
@@ -218,59 +243,66 @@ export type ReferenceValues = {
   skills: Array<Skill>;
 };
 
-export type CharacterDetailFragment = { __typename?: 'Character', id: number, name?: string | null, level?: number | null, hp?: number | null, alignment?: { __typename?: 'Alignment', id?: number | null, alignment?: string | null } | null, race?: { __typename?: 'Race', id?: number | null, raceName?: string | null, raceType?: string | null } | null, class?: { __typename?: 'Class', id?: number | null, className?: string | null } | null };
+export type CharacterDetailFragment = { __typename?: 'Character', id: number, name?: string | null, level?: number | null, hp?: number | null, alignment?: { __typename?: 'Alignment', id: number, alignment: string } | null, race?: { __typename?: 'Race', id: number, raceName: string, raceType: string } | null, class?: { __typename?: 'Class', id: number, className: string } | null };
 
-export type GetCharactersQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetCharactersQueryVariables = Exact<{
+  input: QueryCharactersInput;
+}>;
 
 
-export type GetCharactersQuery = { __typename?: 'Query', characters: Array<{ __typename?: 'Character', id: number, name?: string | null, level?: number | null, hp?: number | null, alignment?: { __typename?: 'Alignment', id?: number | null, alignment?: string | null } | null, race?: { __typename?: 'Race', id?: number | null, raceName?: string | null, raceType?: string | null } | null, class?: { __typename?: 'Class', id?: number | null, className?: string | null } | null }> };
+export type GetCharactersQuery = { __typename?: 'Query', characters: { __typename?: 'CharactersPage', totalCount: number, totalPages: number, currentPage: number, pageSize: number, hasNextPage: boolean, hasPreviousPage: boolean, characters: Array<{ __typename?: 'Character', id: number, name?: string | null, level?: number | null, hp?: number | null, alignment?: { __typename?: 'Alignment', id: number, alignment: string } | null, race?: { __typename?: 'Race', id: number, raceName: string, raceType: string } | null, class?: { __typename?: 'Class', id: number, className: string } | null }> } };
 
 export type GetSingleCharacterQueryVariables = Exact<{
   id: Scalars['Int']['input'];
 }>;
 
 
-export type GetSingleCharacterQuery = { __typename?: 'Query', character?: { __typename?: 'Character', initiative?: number | null, proficiencyBonus?: number | null, speed?: number | null, id: number, name?: string | null, level?: number | null, hp?: number | null, skills?: Array<{ __typename?: 'CharacterSkill', id?: number | null, skillProficiency?: number | null, skill?: { __typename?: 'Skill', id?: number | null, skill?: string | null } | null } | null> | null, abilities?: Array<{ __typename?: 'CharacterAbility', id?: number | null, abilityScore?: number | null, proficiencyBonus?: number | null, ability?: { __typename?: 'Ability', id?: number | null, ability?: string | null } | null } | null> | null, alignment?: { __typename?: 'Alignment', id?: number | null, alignment?: string | null } | null, race?: { __typename?: 'Race', id?: number | null, raceName?: string | null, raceType?: string | null } | null, class?: { __typename?: 'Class', id?: number | null, className?: string | null } | null } | null };
+export type GetSingleCharacterQuery = { __typename?: 'Query', character?: { __typename?: 'Character', initiative?: number | null, proficiencyBonus?: number | null, speed?: number | null, id: number, name?: string | null, level?: number | null, hp?: number | null, skills?: Array<{ __typename?: 'CharacterSkill', id?: number | null, skillProficiency?: number | null, skill?: { __typename?: 'Skill', id: number, skill: string } | null } | null> | null, abilities?: Array<{ __typename?: 'CharacterAbility', id?: number | null, abilityScore?: number | null, proficiencyBonus?: number | null, ability?: { __typename?: 'Ability', id: number, ability: string } | null } | null> | null, alignment?: { __typename?: 'Alignment', id: number, alignment: string } | null, race?: { __typename?: 'Race', id: number, raceName: string, raceType: string } | null, class?: { __typename?: 'Class', id: number, className: string } | null } | null };
 
 export type GetPartialCharacterByIdQueryVariables = Exact<{
   id: Scalars['Int']['input'];
 }>;
 
 
-export type GetPartialCharacterByIdQuery = { __typename?: 'Query', character?: { __typename?: 'Character', id: number, name?: string | null, level?: number | null, hp?: number | null, alignment?: { __typename?: 'Alignment', id?: number | null, alignment?: string | null } | null, race?: { __typename?: 'Race', id?: number | null, raceName?: string | null, raceType?: string | null } | null, class?: { __typename?: 'Class', id?: number | null, className?: string | null } | null } | null };
+export type GetPartialCharacterByIdQuery = { __typename?: 'Query', character?: { __typename?: 'Character', id: number, name?: string | null, level?: number | null, hp?: number | null, alignment?: { __typename?: 'Alignment', id: number, alignment: string } | null, race?: { __typename?: 'Race', id: number, raceName: string, raceType: string } | null, class?: { __typename?: 'Class', id: number, className: string } | null } | null };
 
 export type GetRacesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetRacesQuery = { __typename?: 'Query', races: Array<{ __typename?: 'Race', id?: number | null, raceName?: string | null, raceType?: string | null }> };
+export type GetRacesQuery = { __typename?: 'Query', races: Array<{ __typename?: 'Race', id: number, raceName: string, raceType: string }> };
 
 export type GetClassesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetClassesQuery = { __typename?: 'Query', classes: Array<{ __typename?: 'Class', id?: number | null, className?: string | null }> };
+export type GetClassesQuery = { __typename?: 'Query', classes: Array<{ __typename?: 'Class', id: number, className: string }> };
 
 export type GetAlignmentsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAlignmentsQuery = { __typename?: 'Query', alignments: Array<{ __typename?: 'Alignment', id?: number | null, alignment?: string | null }> };
+export type GetAlignmentsQuery = { __typename?: 'Query', alignments: Array<{ __typename?: 'Alignment', id: number, alignment: string }> };
 
 export type GetSkillsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetSkillsQuery = { __typename?: 'Query', skills: Array<{ __typename?: 'Skill', id?: number | null, skill?: string | null }> };
+export type GetSkillsQuery = { __typename?: 'Query', skills: Array<{ __typename?: 'Skill', id: number, skill: string }> };
 
 export type GetAbilitiesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAbilitiesQuery = { __typename?: 'Query', abilities: Array<{ __typename?: 'Ability', id?: number | null, ability?: string | null }> };
+export type GetAbilitiesQuery = { __typename?: 'Query', abilities: Array<{ __typename?: 'Ability', id: number, ability: string }> };
 
 export type GetreferenceValuesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetreferenceValuesQuery = { __typename?: 'Query', referenceValues: { __typename?: 'referenceValues', races: Array<{ __typename?: 'Race', id?: number | null, raceName?: string | null, raceType?: string | null }>, classes: Array<{ __typename?: 'Class', id?: number | null, className?: string | null }>, abilities: Array<{ __typename?: 'Ability', id?: number | null, ability?: string | null }>, skills: Array<{ __typename?: 'Skill', id?: number | null, skill?: string | null }>, alignments: Array<{ __typename?: 'Alignment', id?: number | null, alignment?: string | null }> } };
+export type GetreferenceValuesQuery = { __typename?: 'Query', referenceValues: { __typename?: 'referenceValues', races: Array<{ __typename?: 'Race', id: number, raceName: string, raceType: string }>, classes: Array<{ __typename?: 'Class', id: number, className: string }>, abilities: Array<{ __typename?: 'Ability', id: number, ability: string }>, skills: Array<{ __typename?: 'Skill', id: number, skill: string }>, alignments: Array<{ __typename?: 'Alignment', id: number, alignment: string }> } };
+
+export type GetCharacterFiltersReferenceValuesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetCharacterFiltersReferenceValuesQuery = { __typename?: 'Query', referenceValues: { __typename?: 'referenceValues', races: Array<{ __typename?: 'Race', id: number, raceName: string, raceType: string }>, classes: Array<{ __typename?: 'Class', id: number, className: string }>, alignments: Array<{ __typename?: 'Alignment', id: number, alignment: string }> } };
 
 export const CharacterDetailFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CharacterDetail"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Character"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"level"}},{"kind":"Field","name":{"kind":"Name","value":"hp"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"race"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"class"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"className"}}]}}]}}]} as unknown as DocumentNode<CharacterDetailFragment, unknown>;
-export const GetCharactersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetCharacters"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"characters"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CharacterDetail"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CharacterDetail"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Character"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"level"}},{"kind":"Field","name":{"kind":"Name","value":"hp"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"race"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"class"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"className"}}]}}]}}]} as unknown as DocumentNode<GetCharactersQuery, GetCharactersQueryVariables>;
+export const GetCharactersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetCharacters"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"QueryCharactersInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"characters"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"characters"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CharacterDetail"}}]}},{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"totalPages"}},{"kind":"Field","name":{"kind":"Name","value":"currentPage"}},{"kind":"Field","name":{"kind":"Name","value":"pageSize"}},{"kind":"Field","name":{"kind":"Name","value":"hasNextPage"}},{"kind":"Field","name":{"kind":"Name","value":"hasPreviousPage"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CharacterDetail"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Character"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"level"}},{"kind":"Field","name":{"kind":"Name","value":"hp"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"race"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"class"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"className"}}]}}]}}]} as unknown as DocumentNode<GetCharactersQuery, GetCharactersQueryVariables>;
 export const GetSingleCharacterDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetSingleCharacter"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"character"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CharacterDetail"}},{"kind":"Field","name":{"kind":"Name","value":"initiative"}},{"kind":"Field","name":{"kind":"Name","value":"proficiencyBonus"}},{"kind":"Field","name":{"kind":"Name","value":"speed"}},{"kind":"Field","name":{"kind":"Name","value":"skills"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"skill"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"skill"}}]}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"skillProficiency"}}]}},{"kind":"Field","name":{"kind":"Name","value":"abilities"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"abilityScore"}},{"kind":"Field","name":{"kind":"Name","value":"proficiencyBonus"}},{"kind":"Field","name":{"kind":"Name","value":"ability"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ability"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CharacterDetail"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Character"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"level"}},{"kind":"Field","name":{"kind":"Name","value":"hp"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"race"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"class"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"className"}}]}}]}}]} as unknown as DocumentNode<GetSingleCharacterQuery, GetSingleCharacterQueryVariables>;
 export const GetPartialCharacterByIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getPartialCharacterById"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"character"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CharacterDetail"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"CharacterDetail"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Character"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"level"}},{"kind":"Field","name":{"kind":"Name","value":"hp"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"}}]}},{"kind":"Field","name":{"kind":"Name","value":"race"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"class"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"className"}}]}}]}}]} as unknown as DocumentNode<GetPartialCharacterByIdQuery, GetPartialCharacterByIdQueryVariables>;
 export const GetRacesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetRaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"races"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}}]}}]} as unknown as DocumentNode<GetRacesQuery, GetRacesQueryVariables>;
@@ -279,6 +311,7 @@ export const GetAlignmentsDocument = {"kind":"Document","definitions":[{"kind":"
 export const GetSkillsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetSkills"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"skills"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"skill"}}]}}]}}]} as unknown as DocumentNode<GetSkillsQuery, GetSkillsQueryVariables>;
 export const GetAbilitiesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAbilities"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"abilities"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ability"}}]}}]}}]} as unknown as DocumentNode<GetAbilitiesQuery, GetAbilitiesQueryVariables>;
 export const GetreferenceValuesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetreferenceValues"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"referenceValues"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"races"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"classes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"className"}}]}},{"kind":"Field","name":{"kind":"Name","value":"abilities"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ability"}}]}},{"kind":"Field","name":{"kind":"Name","value":"skills"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"skill"}}]}},{"kind":"Field","name":{"kind":"Name","value":"alignments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"}}]}}]}}]}}]} as unknown as DocumentNode<GetreferenceValuesQuery, GetreferenceValuesQueryVariables>;
+export const GetCharacterFiltersReferenceValuesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetCharacterFiltersReferenceValues"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"referenceValues"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"races"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"raceName"}},{"kind":"Field","name":{"kind":"Name","value":"raceType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"classes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"className"}}]}},{"kind":"Field","name":{"kind":"Name","value":"alignments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"alignment"}}]}}]}}]}}]} as unknown as DocumentNode<GetCharacterFiltersReferenceValuesQuery, GetCharacterFiltersReferenceValuesQueryVariables>;
 
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -357,14 +390,16 @@ export type ResolversTypes = {
   Character: ResolverTypeWrapper<Character>;
   CharacterAbility: ResolverTypeWrapper<CharacterAbility>;
   CharacterSkill: ResolverTypeWrapper<CharacterSkill>;
+  CharactersPage: ResolverTypeWrapper<CharactersPage>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   Class: ResolverTypeWrapper<Class>;
   CreateCharacterInput: CreateCharacterInput;
   Mutation: ResolverTypeWrapper<{}>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   NewCharacterAbilityInput: NewCharacterAbilityInput;
   NewCharacterInput: NewCharacterInput;
   NewCharacterSkillInput: NewCharacterSkillInput;
   Query: ResolverTypeWrapper<{}>;
+  QueryCharactersInput: QueryCharactersInput;
   Race: ResolverTypeWrapper<Race>;
   Skill: ResolverTypeWrapper<Skill>;
   UpdateCharacterAbilityInput: UpdateCharacterAbilityInput;
@@ -382,14 +417,16 @@ export type ResolversParentTypes = {
   Character: Character;
   CharacterAbility: CharacterAbility;
   CharacterSkill: CharacterSkill;
+  CharactersPage: CharactersPage;
+  Boolean: Scalars['Boolean']['output'];
   Class: Class;
   CreateCharacterInput: CreateCharacterInput;
   Mutation: {};
-  Boolean: Scalars['Boolean']['output'];
   NewCharacterAbilityInput: NewCharacterAbilityInput;
   NewCharacterInput: NewCharacterInput;
   NewCharacterSkillInput: NewCharacterSkillInput;
   Query: {};
+  QueryCharactersInput: QueryCharactersInput;
   Race: Race;
   Skill: Skill;
   UpdateCharacterAbilityInput: UpdateCharacterAbilityInput;
@@ -399,14 +436,14 @@ export type ResolversParentTypes = {
 };
 
 export type AbilityResolvers<ContextType = any, ParentType extends ResolversParentTypes['Ability'] = ResolversParentTypes['Ability']> = {
-  ability?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  ability?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type AlignmentResolvers<ContextType = any, ParentType extends ResolversParentTypes['Alignment'] = ResolversParentTypes['Alignment']> = {
-  alignment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  alignment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -444,9 +481,20 @@ export type CharacterSkillResolvers<ContextType = any, ParentType extends Resolv
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type CharactersPageResolvers<ContextType = any, ParentType extends ResolversParentTypes['CharactersPage'] = ResolversParentTypes['CharactersPage']> = {
+  characters?: Resolver<Array<ResolversTypes['Character']>, ParentType, ContextType>;
+  currentPage?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  hasNextPage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  hasPreviousPage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  pageSize?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalPages?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ClassResolvers<ContextType = any, ParentType extends ResolversParentTypes['Class'] = ResolversParentTypes['Class']> = {
-  className?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  className?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -462,7 +510,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   alignment?: Resolver<Maybe<ResolversTypes['Alignment']>, ParentType, ContextType, RequireFields<QueryAlignmentArgs, 'id'>>;
   alignments?: Resolver<Array<ResolversTypes['Alignment']>, ParentType, ContextType>;
   character?: Resolver<Maybe<ResolversTypes['Character']>, ParentType, ContextType, RequireFields<QueryCharacterArgs, 'id'>>;
-  characters?: Resolver<Array<ResolversTypes['Character']>, ParentType, ContextType>;
+  characters?: Resolver<ResolversTypes['CharactersPage'], ParentType, ContextType, RequireFields<QueryCharactersArgs, 'input'>>;
   class?: Resolver<Maybe<ResolversTypes['Class']>, ParentType, ContextType, RequireFields<QueryClassArgs, 'id'>>;
   classes?: Resolver<Array<ResolversTypes['Class']>, ParentType, ContextType>;
   race?: Resolver<Maybe<ResolversTypes['Race']>, ParentType, ContextType, RequireFields<QueryRaceArgs, 'id'>>;
@@ -473,15 +521,15 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type RaceResolvers<ContextType = any, ParentType extends ResolversParentTypes['Race'] = ResolversParentTypes['Race']> = {
-  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  raceName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  raceType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  raceName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  raceType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type SkillResolvers<ContextType = any, ParentType extends ResolversParentTypes['Skill'] = ResolversParentTypes['Skill']> = {
-  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  skill?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  skill?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -500,6 +548,7 @@ export type Resolvers<ContextType = any> = {
   Character?: CharacterResolvers<ContextType>;
   CharacterAbility?: CharacterAbilityResolvers<ContextType>;
   CharacterSkill?: CharacterSkillResolvers<ContextType>;
+  CharactersPage?: CharactersPageResolvers<ContextType>;
   Class?: ClassResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/src/lib/diceSchema/zodSchema.ts
+++ b/src/lib/diceSchema/zodSchema.ts
@@ -1,6 +1,6 @@
 import { z, ZodType } from 'zod';
 
-const numberValidation = z.number({ invalid_type_error: 'A number is required' }).nonnegative();
+const numberValidation = z.number({ invalid_type_error: 'A number is required' }).nonnegative().max(30);
 
 export const schema = z.object({
   'd4Input': numberValidation,

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -31,9 +31,17 @@ const characterDetailFragment = graphql(`
  * graphql query to get all characters
  */
 export const getCharacters = graphql(`
-  query GetCharacters {
-    characters {
-      ...CharacterDetail
+  query GetCharacters($input: QueryCharactersInput!) {
+    characters(input: $input) {
+      characters {
+        ...CharacterDetail
+      }
+      totalCount
+      totalPages
+      currentPage
+      pageSize
+      hasNextPage
+      hasPreviousPage
     }
   }
 `);
@@ -171,6 +179,30 @@ export const getReferenceValues = graphql(`
       skills {
         id
         skill
+      }
+      alignments {
+        id
+        alignment
+      }
+    }
+  }
+`);
+
+/**
+ * getReferenceValues
+ * graphql query to get race, class, alignment data
+ */
+export const getCharacterFiltersReferenceValues = graphql(`
+  query GetCharacterFiltersReferenceValues {
+    referenceValues {
+      races {
+        id
+        raceName
+        raceType
+      }
+      classes {
+        id
+        className
       }
       alignments {
         id


### PR DESCRIPTION
- revamped the characters list page to have pagination.
- default is 12 characters per page, configurable to be 36 or 60 as well.
- slipped in an update limiting dice rolls to a max of 30
- added apollo cache config to merge into and read from cache
- made character list filtering come from the database instead of filtering on the client-side dataset
- moved name A-Z sorting to the sql query